### PR TITLE
Bug - asyncpipe varidiac input

### DIFF
--- a/haystack_experimental/core/pipeline/async_pipeline.py
+++ b/haystack_experimental/core/pipeline/async_pipeline.py
@@ -20,6 +20,7 @@ from haystack.core.pipeline.base import (
     _enqueue_component,
     _enqueue_waiting_component,
     _is_lazy_variadic,
+    _normalize_varidiac_input_data
 )
 from haystack.telemetry import pipeline_running
 
@@ -368,7 +369,7 @@ class AsyncPipeline(PipelineBase):
         self._validate_input(data)
 
         # Normalize the input data
-        components_inputs: Dict[str, Dict[str, Any]] = self._normalize_varidiac_input_data(data)
+        components_inputs: Dict[str, Dict[str, Any]] = _normalize_varidiac_input_data(data)
 
         # These variables are used to detect when we're stuck in a loop.
         # Stuck loops can happen when one or more components are waiting for input but

--- a/haystack_experimental/core/pipeline/async_pipeline.py
+++ b/haystack_experimental/core/pipeline/async_pipeline.py
@@ -19,8 +19,7 @@ from haystack.core.pipeline.base import (
     _dequeue_waiting_component,
     _enqueue_component,
     _enqueue_waiting_component,
-    _is_lazy_variadic,
-    _normalize_varidiac_input_data
+    _is_lazy_variadic
 )
 from haystack.telemetry import pipeline_running
 
@@ -65,6 +64,26 @@ class AsyncPipeline(PipelineBase):
             if async_executor is None
             else async_executor
         )
+    
+    def _normalize_varidiac_input_data(self, data: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+        """
+        Variadic inputs expect their value to be a list, this utility method creates that list from the user's input.
+        """
+        for component_name, component_inputs in data.items():
+            if component_name not in self.graph.nodes:
+                # This is not a component name, it must be the name of one or more input sockets.
+                # Those are handled in a different way, so we skip them here.
+                continue
+            instance = self.graph.nodes[component_name]["instance"]
+            for component_input, input_value in component_inputs.items():
+                if instance.__haystack_input__._sockets_dict[component_input].is_variadic:
+                    # Components that have variadic inputs need to receive lists as input.
+                    # We don't want to force the user to always pass lists, so we convert single values to lists here.
+                    # If it's already a list we assume the component takes a variadic input of lists, so we
+                    # convert it in any case.
+                    data[component_name][component_input] = [input_value]
+
+        return {**data}
 
     async def _run_component(
         self,
@@ -369,7 +388,7 @@ class AsyncPipeline(PipelineBase):
         self._validate_input(data)
 
         # Normalize the input data
-        components_inputs: Dict[str, Dict[str, Any]] = _normalize_varidiac_input_data(data)
+        components_inputs: Dict[str, Dict[str, Any]] = self._normalize_varidiac_input_data(data)
 
         # These variables are used to detect when we're stuck in a loop.
         # Stuck loops can happen when one or more components are waiting for input but


### PR DESCRIPTION
### Related Issues

- fixes #issue-number N/A
- Quick fix for missing `normalize_varidiac_input_data`  at  experimentalasynchronous pipeline support

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

- Tested with provided unit test and via a private agentic approach

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
